### PR TITLE
Merchant index update status

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,9 +29,21 @@ class ItemsController < ApplicationController
   end
 
   def update
-    Item.update(item_params)
-    @item = Item.find(params[:id])
-    redirect_to "/items/#{@item.id}", alert: "#{@item.name} has been updated"
+    if params[:status] == "enable"
+      merchant = Merchant.find(params[:merchant_id])
+      @item = Item.find(params[:id])
+      @item.update(status: 1)
+      redirect_to "/merchants/#{merchant.id}/items"
+    elsif params[:status] == "disable"
+      merchant = Merchant.find(params[:merchant_id])
+      @item = Item.find(params[:id])
+      @item.update(status: "disabled")
+      redirect_to "/merchants/#{merchant.id}/items"
+    else
+      Item.update(item_params)
+      @item = Item.find(params[:id])
+      redirect_to "/items/#{@item.id}", alert: "#{@item.name} has been updated"
+    end
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -25,3 +25,28 @@
     <hr/>
   <% end %>
 </div>
+
+<% @disabled_items = @merchant.items.find_all {|item| item.status == 0}%>
+
+<h2>Disabled Items:</h2>
+<% @disabled_items.each do |item| %>
+  <h3> <%= item.name %> </h3>
+  <p> <%= item.description %> </p>
+  <h4> Price: $<%= item.unit_price.to_f / 100 %> </h4>
+  <div id="DisabledItem-<%= item.id %>">
+    <%= button_to "Enable Item", "/merchants/#{@merchant.id}/items/#{item.id}?status=enable", method: :patch %>
+  </div>
+  <hr/>
+<% end %>
+<% @enabled_items = @merchant.items.find_all {|item| item.status == 1} %>
+
+<h2>Enabled Items:</h2>
+<% @enabled_items.each do |item| %>
+  <h3> <%= item.name %> </h3>
+  <p> <%= item.description %> </p>
+  <h4> Price: $<%= item.unit_price.to_f / 100 %> </h4>
+  <div id="EnabledItem-<%= item.id %>">
+    <%= button_to "Disable Item", "/merchants/#{@merchant.id}/items/#{item.id}?status=disable", method: :patch %>
+  </div>
+  <hr/>
+<% end %>

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -242,4 +242,27 @@ describe 'merchant item index page' do
       expect(page).not_to have_content(@beer.name)
     end
   end
+
+  it "has a button to change item status" do
+    save_and_open_page
+    within("#DisabledItem-#{@cup.id}") do
+      expect(page).to_not have_button("Disable Item")
+      click_button("Enable Item")
+    end
+
+    expect(current_path).to eq("/merchants/#{@merchant_1.id}/items")
+    save_and_open_page
+    within("#EnabledItem-#{@cup.id}") do
+      expect(page).to_not have_button("Enable Item")
+      expect(page).to have_button("Disable Item")
+      click_button("Disable Item")
+    end
+
+    expect(current_path).to eq("/merchants/#{@merchant_1.id}/items")
+    save_and_open_page
+    within("#DisabledItem-#{@cup.id}") do
+      expect(page).to have_button("Enable Item")
+      expect(page).to_not have_button("Disable Item")
+    end
+  end
 end


### PR DESCRIPTION
Alright boys. Here lies the end of a 'push origin main' disaster.
These stories work with the Items index view, and I noticed we have two: one in /views/items/index.html.erb, and one in /views/merchants/item_index.html.erb
I put my logic in the former, and I guess we'll just consolidate both into one page at some point? 

This push completes stories #32 & #31:
- Item index has a Disabled Items and Enabled Items section
- Each item in these section has a corresponding button to `enable` or `disable` the item
- These buttons update the status of the item, and they are then shown in the corresponding section on the index page
